### PR TITLE
fix ArrayIndexOutOfBoundsException in WatchProcesses

### DIFF
--- a/src/main/java/com/application/model/Model.java
+++ b/src/main/java/com/application/model/Model.java
@@ -704,9 +704,9 @@ public class Model {
 			String line = null;
 
 			while((line = reader.readLine())!= null ){
-				String[] processLine = line.split("\\s+");
-				String pid = processLine[1];
-				String pName = processLine[2];
+				String[] processLine = line.strip().split("\\s+");
+				String pid = processLine[0];
+				String pName = processLine[1];
 				SystemProcess tempProc = new SystemProcess();
 
 				Map <String, JSONObject> measurements = new HashMap<>();
@@ -715,14 +715,14 @@ public class Model {
 				cpu.put("alternativeLabel", "CPU%");
 				cpu.put("capturedDate", captureTime);
 				cpu.put("measurementTypeId", "5");
-				cpu.put("value", processLine[4]);
+				cpu.put("value", processLine[3]);
 				measurements.put("Cpu",cpu);
 
 				JSONObject mem = new JSONObject();
 				mem.put("alternativeLabel", "MEM%");
 				mem.put("capturedDate", captureTime);
 				mem.put("measurementTypeId", "3");
-				mem.put("value", processLine[3]);
+				mem.put("value", processLine[2]);
 				measurements.put("Mem",mem);
 
 				tempProc.setProcessValues(this, measurements, captureTime, pid, pName);


### PR DESCRIPTION
If PID of process is greater than 10000, then processLine.length is not 5 but 4. Thus, it is not always possible to get processLine[4].
![image](https://user-images.githubusercontent.com/32509100/100016219-1c942480-2dea-11eb-95fe-971d009b051b.png)
